### PR TITLE
Cap openai below 3 and move LiteLLM to current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,18 @@ jobs:
       - name: Install dependencies
         run: make install
 
+      # Catches packages whose installed versions violate another installed
+      # package's declared requirements. Cheap, and it fails the job rather
+      # than printing into a log nobody reads.
+      #
+      # Stated plainly: this would NOT have caught the 2026-09-03 openai/LiteLLM
+      # incident, because litellm 1.83.0's metadata was satisfied by openai 3 —
+      # it simply predated the bound later releases added. Metadata checks can
+      # only enforce what upstream declared. The guard against that failure is
+      # the version floors and caps in requirements.txt, not this step.
+      - name: Check for dependency conflicts
+        run: python -m pip check
+
       - name: Run the test suite
         run: make test-fast
 

--- a/docs/security/dependabot-triage-2026-09.md
+++ b/docs/security/dependabot-triage-2026-09.md
@@ -116,3 +116,61 @@ reviewer's reading of a changelog.
   own floor-only constraint. CI answers this per-PR from here on, but no
   exhaustive sweep of latest-version resolution was performed in this pass.
 - `mcp` 2.x compatibility, deliberately deferred as above.
+
+## Addendum — the openai/LiteLLM resolution defect (same day)
+
+Recorded separately because it was *caused* by a merge in this pass, and the
+mechanism is the more useful part.
+
+### What happened
+
+PR #68 raised `openai` from `>=2.32.0` to `>=3.6.0`. CI passed and it merged.
+It should not have.
+
+LiteLLM caps openai at `<3.0.0` in every release from 1.90.0 onward. LiteLLM
+1.83.0 — the floor this file has carried since the March-2026 supply-chain
+incident — declares only `openai>=2.8.0`, because it predates openai 3
+entirely. So `openai>=3.6.0` did not produce a conflict. It produced a
+resolution: pip reached back to the single LiteLLM release old enough not to
+forbid openai 3, and installed **litellm 1.83.0 with openai 3.7.0**.
+
+That pairing is one upstream forbids in every version that knew to. It is
+worse than a failed install, for three reasons:
+
+1. **It installs.** `pip check` passes, because 1.83.0's metadata is satisfied.
+2. **The suite passes.** Provider calls are mocked, so nothing exercises the
+   combination. Green CI carried no information about it.
+3. **It froze the default gateway.** LiteLLM sat pinned at exactly the oldest
+   release the security note permits, with no upgrade path while the openai
+   floor stood — the opposite of what a security floor is for.
+
+### The decision
+
+Capped openai at `<3` and raised LiteLLM's floor to the current release.
+
+ragbot needs nothing from openai 3.x: every call site uses the stable
+`openai.OpenAI()` client present in both majors, so the floor bump bought no
+capability. Against that, LiteLLM is the default backend and the broadest
+provider surface, and it had been sixteen versions behind.
+
+Resolved after the change: **litellm 1.99.0, openai 2.54.0**, 896 tests
+passing, `pip check` clean.
+
+"Up to date" is the whole point here, and it argued *for* this: openai 3 with
+a 2026-era LiteLLM is not a more current ragbot, it is a ragbot whose gateway
+cannot move. The alternative — dropping LiteLLM for the `direct` backend,
+which uses provider SDKs and has no such cap — remains open, and is the right
+conversation to have deliberately rather than as a side effect of a bot's
+version bump.
+
+### The generalisation
+
+This is the floor-only convention biting a second time in one day, and worse
+than the first. The `mcp` case was a missing ceiling letting a breaking major
+in. This one is subtler: **a floor raised on one package silently dragged
+another package backwards**, because the resolver will reach arbitrarily far
+back to satisfy a constraint set, and nothing in that process asks whether the
+combination is one anybody has ever run.
+
+`pip check` is now in CI. It is worth having, and it would not have caught
+this. The guard that does is the pair of bounds in `requirements.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,17 +2,45 @@
 # Updated: April 2026 — latest stable versions across the stack.
 
 # --- Provider SDKs --------------------------------------------------------
-# Versions track the post-March-2026 LiteLLM supply-chain incident: pin
-# litellm >= 1.83 (compromised range was 1.82.7-1.82.8). See
+# Versions track the post-March-2026 LiteLLM supply-chain incident: the
+# compromised range was 1.82.7-1.82.8. See
 # https://docs.litellm.ai/blog/security-update-march-2026.
+#
+# The floor was 1.83.0 — the first release after that range — and stayed there
+# because it was the minimum, not because it was the intent. On 2026-09-03 the
+# resolver was found pinning litellm to exactly 1.83.0, so the default gateway
+# was running the oldest version the incident permits and had been for months.
+# The floor is now the current release: being just past a known-compromised
+# range is not the same as being current, and a security floor that never
+# moves is a ceiling.
 anthropic>=0.97.0
-openai>=3.6.0
+# The `<3` is load-bearing and was learned the hard way on 2026-09-03.
+#
+# LiteLLM caps openai at `<3.0.0` in every release that knows openai 3 exists
+# (1.90.0 onward). LiteLLM 1.83.0 declares only `openai>=2.8.0` — not because
+# it is compatible with openai 3, but because it predates it.
+#
+# So a bare `openai>=3.6.0` did not fail. It resolved: pip reached back to the
+# single LiteLLM release old enough not to forbid openai 3, and installed
+# litellm 1.83.0 with openai 3.7.0 — a pairing upstream forbids everywhere it
+# knew to. That is worse than a conflict, because it installs and the test
+# suite passes: the suite mocks provider calls, so nothing exercises the
+# combination. It also froze the default gateway on the oldest release the
+# security note above permits, leaving no upgrade path.
+#
+# ragbot itself needs nothing from openai 3.x — every call site uses the
+# stable `openai.OpenAI()` client present in both majors. The floor bump
+# bought no capability and cost LiteLLM sixteen versions of fixes.
+#
+# Lift this cap only when LiteLLM ships a release accepting openai 3.x, or if
+# the `direct` backend becomes the default and LiteLLM is dropped outright.
+openai>=2.32.0,<3
 # google-generativeai is end-of-life; kept as a transitive dep that LiteLLM
 # and other tools still pull in. Direct usage in the compiler has migrated
 # to google-genai (see below).
 google-generativeai>=0.8.6
 google-genai>=2.20.0
-litellm>=1.83.0
+litellm>=1.99.0
 tiktoken>=0.12.0
 
 # --- LangChain (used by some downstream callers) -------------------------


### PR DESCRIPTION
Fixes a defect introduced by #68 earlier today. CI passed on that PR and it merged; it should not have.

## What actually happened

LiteLLM caps `openai<3.0.0` in **every release from 1.90.0 onward**. LiteLLM 1.83.0 — the floor `requirements.txt` has carried since the March-2026 supply-chain incident — declares only `openai>=2.8.0`, because it predates openai 3 entirely.

So `openai>=3.6.0` did not conflict. It **resolved**: pip reached back to the single LiteLLM release old enough not to forbid openai 3, and installed `litellm 1.83.0` with `openai 3.7.0` — a pairing upstream forbids everywhere it knew to.

That is worse than a failed install:

| | |
|---|---|
| It installs | `pip check` passes — 1.83.0's metadata is satisfied |
| The suite passes | provider calls are mocked; nothing exercises the pair |
| It froze the gateway | LiteLLM pinned at exactly the oldest release the security note permits, with no upgrade path |

## The decision

`openai>=2.32.0,<3` and `litellm>=1.99.0`.

ragbot needs nothing from openai 3.x — every call site uses the stable `openai.OpenAI()` client present in both majors, so the floor bump bought no capability. Against that, LiteLLM is the default backend and the broadest provider surface, and it was **sixteen versions behind**.

Staying current argues *for* this. openai 3 with a months-old LiteLLM is not a more current ragbot; it is one whose gateway cannot move. Retiring LiteLLM for the `direct` backend — which uses provider SDKs and has no such cap — remains open, and deserves to be a deliberate architectural choice rather than a side effect of a bot's version bump.

## Verification, from a clean container

| | before | after |
|---|---|---|
| litellm | 1.83.0 (floor) | **1.99.0** (current) |
| openai | 3.7.0 (unsupported pairing) | **2.54.0** |
| tests | 896 pass | **896 pass** |
| `pip check` | clean | clean |

## Also

Adds `pip check` to CI, labelled honestly in the workflow: **it would not have caught this**, because the old release's metadata was satisfied. Metadata checks enforce only what upstream declared. The guard against this failure is the pair of bounds in `requirements.txt`.

Full write-up, including the generalisation — a floor raised on one package silently dragging another backwards — in `docs/security/dependabot-triage-2026-09.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)